### PR TITLE
Adjust workflow triggers to reduce scheduled usage

### DIFF
--- a/.github/workflows/ci-deploy-gh-pages.yml
+++ b/.github/workflows/ci-deploy-gh-pages.yml
@@ -2,6 +2,7 @@
 name: Deploy GitHub Pages
 concurrency: preview-deploy-${{ github.ref }}
 on:
+  # need credits
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 on:
   release:
     types: [published]
+  # need credits
   pull_request:
     branches: '**'
     paths-ignore:
       - '**.md'
+  # need credits
   push:
     branches:
       - develop

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,9 +1,11 @@
 name: 'Code scanning - action'
 
 on:
+  # need credits
   push:
     branches-ignore:
       - dependabot/**
+  # need credits
   pull_request:
   #schedule:
   #  - cron: '0 13 * * *'

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,5 +1,6 @@
 name: 'PR Title Checker'
 on:
+  # need credits
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/pr-update-description.yml
+++ b/.github/workflows/pr-update-description.yml
@@ -1,6 +1,7 @@
 name: 'Release PR Description'
 
 on:
+  # need credits
   pull_request:
     branches:
       - master

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,6 +1,7 @@
 name: Publish Final Release
 
 on:
+  # need credits
   push:
     branches:
       - master

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,7 +1,12 @@
 name: Release candidate cut
 on:
-  schedule:
-    - cron: '28 12 20 * *' # run at minute 28 to avoid the chance of delay due to high load on GH
+  # need credits
+  push:
+    branches:
+      - develop
+      - master
+      - release-candidate
+  workflow_dispatch:
 jobs:
   new-release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,10 @@
 name: Close inactive issues
 on:
-  schedule:
-    - cron: '0 */6 * * *'
+  # need credits
+  push:
+    branches:
+      - develop
+      - master
 
 jobs:
   close-issues:


### PR DESCRIPTION
## Summary
- remove scheduled triggers from workflows that ran automatically without interaction
- add push-based triggers and manual dispatch options where appropriate so they only run on commits or request
- annotate commit- and PR-driven workflows with a `need credits` comment to highlight resource usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d3e7f8988331baad636bc4023c9c